### PR TITLE
Add optional support for systemd sd_notify()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 4.0b2 (unreleased)
 ------------------
 
+- Add optional support for systemd sd_notify().
 - Move ``Products.SiteAccess`` back to `Zope`.
 
 

--- a/docs/operation.rst
+++ b/docs/operation.rst
@@ -37,6 +37,34 @@ pair to bind only to a specific interface.
 After making any changes to the configuration file, you need to restart any
 running ZServer for the affected instance before changes are in effect.
 
+Additionally if you've installed ZServer with the sdnotify extra and you are
+on a Linux distribution using systemd, ZServer will tell your service it is
+ready and also tell it to reset its watchdog timer every 30 seconds.
+
+A sample service file::
+
+    [Unit]
+    Description=A test ZServer service
+
+    [Service]
+    # Note: setting PYTHONUNBUFFERED is necessary to see the output of this
+    # service in the journal
+    # See https://docs.python.org/2/using/cmdline.html#envvar-PYTHONUNBUFFERED
+    Environment=PYTHONUNBUFFERED=true
+
+    # Adjust this line to the correct path and params for your Zope instance
+    ExecStart=/path/to/bin/runzope
+
+    # Note that we use Type=notify here since ZServer will send "READY=1"
+    # when it's finished starting up
+    Type=notify
+
+    # We'll assume it needs to get back to us at least every 45s or it is dead
+    WatchdogSec=45
+
+    # We'll always kick it back up if it is in a failure state
+    # There are other values for this, including on-watchdog, read systemd docs
+    Restart=always
 
 Running ZServer in the Foreground
 ---------------------------------

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ setup(
         'zope.testing',
         'Zope > 4.0b2',
     ],
+    extras_require={
+        'sdnotify': ['sdnotify'],
+    },
     include_package_data=True,
     zip_safe=False,
     entry_points={

--- a/src/ZServer/Zope2/Startup/starter.py
+++ b/src/ZServer/Zope2/Startup/starter.py
@@ -32,6 +32,13 @@ try:
 except NameError:
     IO_ERRORS = (IOError, OSError, )
 
+# Optional systemd sd_notify() readiness announcement support
+try:
+    from sdnotify import SystemdNotifier
+    _SD_NOTIFY_READINESS = True
+except ImportError:
+    _SD_NOTIFY_READINESS = False
+
 logger = logging.getLogger("Zope")
 
 
@@ -80,6 +87,9 @@ class ZopeStarter(object):
         config = getConfiguration()  # NOQA
         self.registerSignals()
         logger.info('Ready to handle requests')
+        if _SD_NOTIFY_READINESS:
+            SystemdNotifier().notify('READY=1')
+            logger.info('Notifying systemd of readiness')
         self.sendEvents()
 
     def dropPrivileges(self):


### PR DESCRIPTION
Systemd provides a neat way for services to announce themselves to be ready or not dead yet.

https://www.freedesktop.org/software/systemd/man/sd_notify.html
https://www.freedesktop.org/software/systemd/man/systemd.service.html

I've implemented and documented both for ZServer as an optional extra.