### PR TITLE
Pin a suitable buildout for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - 2.7
 install:
     - pip install -U setuptools==33.1.1 zc.buildout==2.9.5 six==1.10.0
-    - pip install zc.buildout
     - buildout bootstrap
     - buildout
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - 2.7
 install:
     - pip install -U setuptools==33.1.1 zc.buildout==2.9.5 six==1.10.0
-    - buildout bootstrap
     - buildout
 script:
     - bin/test -v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
     - 2.7
 install:
-    - pip install -U setuptools==33.1.1
+    - pip install -U setuptools==33.1.1 zc.buildout==2.9.5
     - pip install zc.buildout
     - buildout bootstrap
     - buildout

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
     - 2.7
 install:
-    - pip install -U setuptools==33.1.1 zc.buildout==2.9.5
+    - pip install -U setuptools==33.1.1 zc.buildout==2.9.5 six==1.10.0
     - pip install zc.buildout
     - buildout bootstrap
     - buildout


### PR DESCRIPTION
The reality of testing on Travis has once again slipped from under the feet.

* No need to bootstrap if buildout comes in via pip
* Pin setuptools, buildout and six for the build