### PR TITLE
allow multithreading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Changelog
 4.0 (2019-05-08)
 ----------------
 
-ZChanges since 3.0:
+Changes since 3.0:
 
 - Broke out ZServer and related code from Zope core project.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Fix: ``zserver-threads`` configuration option has been ineffective due
+  to too early import of the configuration variable
+  (`Zope#665 <https://github.com/zopefoundation/Zope/issues/665>`_).
+
 
 4.0.1 (2019-05-17)
 ------------------
@@ -14,7 +18,7 @@ Changelog
 4.0 (2019-05-08)
 ----------------
 
-Changes since 3.0:
+ZChanges since 3.0:
 
 - Broke out ZServer and related code from Zope core project.
 

--- a/src/ZServer/PubCore/__init__.py
+++ b/src/ZServer/PubCore/__init__.py
@@ -11,10 +11,6 @@
 #
 ##############################################################################
 
-from ZServer.Zope2.Startup.config import (  # NOQA
-    setNumberOfThreads,
-    ZSERVER_THREADS as _n,
-)
 from ZServer.PubCore import ZRendezvous
 
 _handle = None
@@ -24,6 +20,7 @@ def handle(*args, **kw):
     global _handle
 
     if _handle is None:
+        from ZServer.Zope2.Startup.config import ZSERVER_THREADS as _n
         _handle = ZRendezvous.ZRendevous(_n).handle
 
     return _handle(*args, **kw)


### PR DESCRIPTION
fix https://github.com/zopefoundation/Zope/issues/665

The bug was caused because `ZServer.PubCore` has imported `ZSERVER_THREADS` too early (before the configuration file was processed).